### PR TITLE
Fix an empty resolv.conf if there are no foreign_options

### DIFF
--- a/update-resolv-conf
+++ b/update-resolv-conf
@@ -33,7 +33,10 @@ up)
     R="${R}nameserver $NS
 "
   done
-  echo -n "$R" > /etc/resolv.conf
+
+  if [ "$R" ]; then
+    echo -n "$R" > /etc/resolv.conf
+  fi
   ;;
 
 down)


### PR DESCRIPTION
Hello.

In our setup the loop over `foreign_option_*` had no results causing the up part of update-resolv-conf to create an empty /etc/resolv.conf on the host which in turn caused all DNS resolutions to fail. This fixes this by only overwriting the resolv.conf if there is something for overwriting.

Regards.